### PR TITLE
Remove bqsr report from MultiQC inputs

### DIFF
--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -170,7 +170,6 @@ rule fastqc:
 rule multiqc:
     input:
         expand("qc/fastqc/{sample}_{type}_fastqc.zip", sample=samples, type=types),
-        expand("qc/{sample}.{type}.recal_data.table", sample=samples, type=types),
         expand("qc/{sample}_{type}.mosdepth.region.dist.txt", sample=samples, type=types),
         expand("qc/{sample}.{type}.flagstat", sample=samples, type=types)
     output:


### PR DESCRIPTION
Removes BQSR plots from MultiQC as it seems impossible to make GATK properly specify whether the recalibration data table is for pre or post recalibration scores. Without this setting in the recalibration table, MultiQC can't tell if the data is pre or post and calls it pre