### PR TITLE
Multiplexed samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ at the top of this page. This will allow you to track any changes made to the an
 See the `schemas/` directory for details about each file.
 4. Configure `config.yml`. See `schemas/config.schema.yaml` for info about each required field. 
 There should be normal and tumor samples for each patient. 
-Each patient should have two rows in `units`, one normal row and one tumor row. Sequencing data must be
-paired, so both `fq1` and `fq2` are required.
+Each patient should have at least two rows in `units`, one normal row and one tumor row. 
+Multiplexed samples should be differentiated with the `readgroup` column.
+Sequencing data must be paired, so both `fq1` and `fq2` are required.
 
 ## Environments
 `snakemake` is required to run `ngs-pipeline`, and other programs (`samtools`, `gatk`, etc)

--- a/patients.csv
+++ b/patients.csv
@@ -1,2 +1,3 @@
 patient
 case01
+patient101

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -15,7 +15,7 @@ min_version("5.9.1")
 configfile: "config.yaml"
 validate(config, schema = "../schemas/config.schema.yaml")
 patients = pd.read_csv(config['patients'])['patient']
-units = pd.read_csv(config['units'], dtype=str).set_index(["patient", "sample"], drop=False)
+units = pd.read_csv(config['units'], dtype=str).set_index(["patient", "sample", "readgroup"], drop=False)
 validate(units, schema = "../schemas/units.schema.yaml")
 ref_dir = config['ref_dir']
 ref_fasta = os.path.join(ref_dir, config['ref_fasta'])
@@ -36,11 +36,20 @@ wildcard_constraints:
     sample_type="|".join(sample_types)
 
 def get_fastq(wildcards):
-    return {'r1' : units.loc[(wildcards.patient, wildcards.sample_type), 'fq1'], 
-            'r2' : units.loc[(wildcards.patient, wildcards.sample_type), 'fq2']}
+    return {'r1' : units.loc[(wildcards.patient, wildcards.sample_type, wildcards.readgroup), 'fq1'], 
+            'r2' : units.loc[(wildcards.patient, wildcards.sample_type, wildcards.readgroup), 'fq2']}
+
+def get_readgroups(wildcards):
+    return units.loc[(wildcards.patient, wildcards.sample_type), 
+                    'readgroup'].unique().tolist()
+
+def get_dedup_input(wildcards):
+    rgs = units.loc[(wildcards.patient, wildcards.sample_type), 'readgroup'].unique().tolist()
+    bams = [f"bams/{wildcards.patient}.{wildcards.sample_type}.{rg}.merged.bam" for rg in rgs]
+    return bams
 
 def get_platform(wildcards):
-    return units.loc[(wildcards.patient, wildcards.sample_type), 'platform'][0]
+    return units.loc[(wildcards.patient, wildcards.sample_type, wildcards.readgroup), 'platform'][0]
 
 def get_call_pair(wildcards):
     return {'normal' : f"bams/{wildcards.patient}.normal.bam",

--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -11,7 +11,7 @@ rule combine_fqs:
     input:
         unpack(get_fastq)
     output:
-        temp("bams/{patient}.{sample_type}.unaligned.bam")
+        temp("bams/{patient}.{sample_type}.{readgroup}.unaligned.bam")
     params:
         pl=get_platform
     conda:
@@ -20,7 +20,7 @@ rule combine_fqs:
         """
         gatk FastqToSam -F1 {input.r1} -F2 {input.r2} -O {output} \
             -SM {wildcards.patient}.{wildcards.sample_type} \
-            -RG {wildcards.patient}.{wildcards.sample_type} \
+            -RG {wildcards.patient}.{wildcards.sample_type}.{wildcards.readgroup} \
             -PL {params.pl}
         """
 
@@ -39,10 +39,10 @@ rule bwa_index:
 
 rule bwa:
     input:
-        bam="bams/{patient}.{sample_type}.unaligned.bam",
+        bam="bams/{patient}.{sample_type}.{readgroup}.unaligned.bam",
         ref=ref_fasta
     output:
-        temp("bams/{patient}.{sample_type}.aligned.bam")
+        temp("bams/{patient}.{sample_type}.{readgroup}.aligned.bam")
     threads: 8
     conda:
         "../envs/gatk.yml"
@@ -58,11 +58,11 @@ rule bwa:
 
 rule merge_bams:
     input:
-        unaligned="bams/{patient}.{sample_type}.unaligned.bam",
-        aligned="bams/{patient}.{sample_type}.aligned.bam",
+        unaligned="bams/{patient}.{sample_type}.{readgroup}.unaligned.bam",
+        aligned="bams/{patient}.{sample_type}.{readgroup}.aligned.bam",
         ref=ref_fasta
     output:
-        temp("bams/{patient}.{sample_type}.merged.bam")
+        temp("bams/{patient}.{sample_type}.{readgroup}.merged.bam")
     conda:
         "../envs/gatk.yml"
     shell:
@@ -73,11 +73,14 @@ rule merge_bams:
 
 rule mark_duplicates:
     input:
-        "bams/{patient}.{sample_type}.merged.bam"
+        get_dedup_input
+        # "bams/{patient}.{sample_type}.merged.bam"
     output:
         bam=temp("bams/{patient}.{sample_type}.markdups.bam"),
         md5=temp("bams/{patient}.{sample_type}.markdups.bam.md5"),
         metrics="qc/gatk/{patient}_{sample_type}_dup_metrics.txt"
+    params:
+        inputs=['-I' + b for b in wildcards.input]
     conda:
         "../envs/gatk.yml"
     shell:
@@ -98,6 +101,7 @@ rule sort_fix_tags:
         "../envs/gatk.yml"
     shell:
         """
+
         gatk SortSam -I {input.bam} -O /dev/stdout --SORT_ORDER "coordinate" \
             --CREATE_INDEX false --CREATE_MD5_FILE false \
         | \

--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -80,12 +80,12 @@ rule mark_duplicates:
         md5=temp("bams/{patient}.{sample_type}.markdups.bam.md5"),
         metrics="qc/gatk/{patient}_{sample_type}_dup_metrics.txt"
     params:
-        inputs=['-I' + b for b in wildcards.input]
+        input=lambda wildcards, input: " -I  ".join(input)
     conda:
         "../envs/gatk.yml"
     shell:
         """
-        gatk MarkDuplicates -I {input} -O {output.bam} -M {output.metrics} \
+        gatk MarkDuplicates -I {params.input} -O {output.bam} -M {output.metrics} \
             --CREATE_MD5_FILE true --ASSUME_SORT_ORDER "queryname"
         """
 

--- a/schemas/units.schema.yaml
+++ b/schemas/units.schema.yaml
@@ -10,6 +10,9 @@ properties:
     platform:
         type: string
         description: must be ILLUMINA
+    readgroup:
+        type: string
+        description: unique identifier for all reads sequenced in a certain lane (rg1 for FASTQ from lane 1)
     fq1:
         type: string
         description: filepath for first FASTQ file
@@ -20,6 +23,7 @@ properties:
 required:
     - patient
     - sample
+    - readgroup
     - platform
     - fq1
     - fq2

--- a/units.csv
+++ b/units.csv
@@ -1,3 +1,9 @@
-patient,sample,platform,fq1,fq2
-case01,normal,ILLUMINA,data/tcrb-data/TCRBOA1-N-WEX.R1.fq,data/tcrb-data/TCRBOA1-N-WEX.R2.fq
-case01,tumor,ILLUMINA,data/tcrb-data/TCRBOA1-T-WEX.R1.fq,data/tcrb-data/TCRBOA1-T-WEX.R2.fq
+patient,sample,platform,readgroup,fq1,fq2
+case01,normal,ILLUMINA,rg1,data/tcrb-data/TCRBOA1-N-WEX.R1.fq,data/tcrb-data/TCRBOA1-N-WEX.R2.fq
+case01,tumor,ILLUMINA,rg1,data/tcrb-data/TCRBOA1-T-WEX.R1.fq,data/tcrb-data/TCRBOA1-T-WEX.R2.fq
+patient101,normal,ILLUMINA,rg1,data/multiplex-reads/CTR101-1_1.short.fastq.gz,data/multiplex-reads/CTR101-1_2.short.fastq.gz
+patient101,normal,ILLUMINA,rg2,data/multiplex-reads/CTR101-2_1.short.fastq.gz,data/multiplex-reads/CTR101-2_2.short.fastq.gz
+patient101,normal,ILLUMINA,rg3,data/multiplex-reads/CTR101-3_1.short.fastq.gz,data/multiplex-reads/CTR101-3_2.short.fastq.gz
+patient101,tumor,ILLUMINA,rg1,data/multiplex-reads/T101-1_1.short.fastq.gz,data/multiplex-reads/T101-1_2.short.fastq.gz
+patient101,tumor,ILLUMINA,rg2,data/multiplex-reads/T101-2_1.short.fastq.gz,data/multiplex-reads/T101-2_2.short.fastq.gz
+patient101,tumor,ILLUMINA,rg3,data/multiplex-reads/T101-3_1.short.fastq.gz,data/multiplex-reads/T101-3_2.short.fastq.gz


### PR DESCRIPTION
Close #35 and #42. Adds functionality to handle multiplexed samples that were sequenced over different lanes. Each sample should now specify its read group in the `readgroup` column of `units.csv`. If only one lane was used, set the value to something like `rg1`. 