### PR TITLE
Add Panel of Normals Creation Workflow

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -9,3 +9,4 @@ rule targets:
 
 include: "rules/preprocessing.smk"
 include: "rules/calling.smk"
+include: "rules/pon.smk"

--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,37 @@
+# CSV file with single column, patient, with every patient ID
 patients: patients.csv
+# CSV file with info on each sample
 units: units.csv
+
+# Reference genome sources
+# Directory where reference fasta and supporting files are stored
 ref_dir: data/hg38
+# Name of reference FASTA (should be unzipped)
 ref_fasta: genome.chr21.fa
+# Comma separated names of VCF files with known mutations. 
+# Should all be in the reference directory
 known_sites: dbsnp.vcf.gz
+# BED file with exome regions that were targeted for capture. Doesn't have to be in ref_dir
 exome_targets: data/hg38/hg38.chr21.exons.bed
+# AF only VCF with common allele frequencies - use gnomAD file
 germline_resource: data/hg38/gnomad_short.vcf.gz
+# Biallelic variants only VCF with AF data - use EXAC file
 contamination_resource: data/hg38/contam_short.vcf.gz
+
+# Annotation data sources
+# Directory with VEP annotation data
 vep_dir: /home/groups/carilee/refs/vep_data
+# Reference fasta VEP should use for annotation
 vep_fasta: /home/groups/carilee/refs/vep_data/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz 
+# Assembly version name
 assembly_version: GRCh38
+# Value for Center field in the combined MAF
 center_name: lee-lab
+
+# Panel of Normal (PON)
+# Use PON with Mutect2 for variant calling
+use_pon: true
+# Filepath for PON. To create a new PON from all the normal samples, specify as None
+pon_vcf: None
+# GATK, Picard, or BED style interval file with intervals to use for Panel of Normal Creation
+interval_file: data/hg38/hg38.chr21.intervals

--- a/patients.csv
+++ b/patients.csv
@@ -1,2 +1,3 @@
 patient
 case01
+patient101

--- a/rules/calling.smk
+++ b/rules/calling.smk
@@ -8,7 +8,8 @@
 
 rule mutect2:
     input:
-        unpack(get_call_pair),
+        # unpack(get_call_pair),
+        unpack(get_mutect2_input),
         ref=ref_fasta,
         germ_res=germline_resource
     output:
@@ -18,6 +19,7 @@ rule mutect2:
     params:
         tumor="{patient}.tumor",
         normal="{patient}.normal",
+        pon=lambda wildcards, input: "--panel-of-normals " + pon_vcf,
         extra=""
     threads: 4
     conda:
@@ -27,7 +29,8 @@ rule mutect2:
         gatk Mutect2 -R {input.ref} -I {input.normal} -I {input.tumor} \
             -normal {params.normal} -tumor {params.tumor} -O {output.vcf} \
             --germline-resource {input.germ_res} \
-            {params.extra}
+            --disable-read-filter MateOnSameContigOrNoMappedMateReadFilter \
+            {params.pon} {params.extra}
         """
 
 rule pileup_summaries:

--- a/rules/pon.smk
+++ b/rules/pon.smk
@@ -1,0 +1,48 @@
+# File: pon.smk
+# Author: Tomas Bencomo
+# Description: Workflow to create Panel of Normals for Mutect2
+
+rule mutect2_pon:
+    input:
+        bam="bams/{patient}.normal.bam",
+        ref=ref_fasta
+    output:
+        "pon/{patient}.pon.vcf.gz"
+    conda:
+        "../envs/gatk.yml"
+    shell:
+        """
+        gatk Mutect2 -I {input.bam} -R {input.ref} -O {output} \
+        --disable-read-filter MateOnSameContigOrNoMappedMateReadFilter \
+        -max-mnp-distance 0
+        """
+rule gather_variants:
+    input:
+        vcfs=expand("pon/{patient}.pon.vcf.gz", patient=patients),
+        ref=ref_fasta,
+        intervals=genome_intervals
+    output:
+        directory("pon/pon_db")
+    params:
+        vcfs=lambda wildcards, input: " -V ".join(input.vcfs)
+    conda:
+        "../envs/gatk.yml"
+    shell:
+        """
+        gatk GenomicsDBImport -R {input.ref} --genomicsdb-workspace-path {output} \
+            -V {params.vcfs} -L {input.intervals}
+        """
+
+rule create_pon:
+    input:
+        var="pon/pon_db",
+        ref=ref_fasta
+    output:
+        "pon/pon.vcf.gz"
+    conda:
+        "../envs/gatk.yml"
+    shell:
+        """
+        gatk CreateSomaticPanelOfNormals -R {input.ref} -V gendb://{input.var} -O {output}
+        """
+

--- a/schemas/config.schema.yaml
+++ b/schemas/config.schema.yaml
@@ -41,6 +41,15 @@ properties:
     center_name:
         type: string
         description: name of lab where data was processed. Included in the MAF file generated from vcf2maf
+    use_pon:
+        type: boolean
+        description: use panel of normals for variant calling
+    pon_vcf:
+        type: string
+        description: filepath for PON VCF. To build PON from normal samples, set as None
+    interval_file:
+        type: string
+        description: interval file for regions to include when building PON
 
 required:
     - patients
@@ -55,3 +64,6 @@ required:
     - vep_fasta
     - assembly_version
     - center_name
+    - use_pon
+    - pon_vcf
+    - interval_file

--- a/units.csv
+++ b/units.csv
@@ -1,3 +1,9 @@
 patient,sample,platform,readgroup,fq1,fq2
 case01,normal,ILLUMINA,rg1,data/tcrb-data/TCRBOA1-N-WEX.R1.fq,data/tcrb-data/TCRBOA1-N-WEX.R2.fq
 case01,tumor,ILLUMINA,rg1,data/tcrb-data/TCRBOA1-T-WEX.R1.fq,data/tcrb-data/TCRBOA1-T-WEX.R2.fq
+patient101,normal,ILLUMINA,rg1,data/multiplex-reads/CTR101-1_1.short.fastq.gz,data/multiplex-reads/CTR101-1_2.short.fastq.gz
+patient101,normal,ILLUMINA,rg2,data/multiplex-reads/CTR101-2_1.short.fastq.gz,data/multiplex-reads/CTR101-2_2.short.fastq.gz
+patient101,normal,ILLUMINA,rg3,data/multiplex-reads/CTR101-3_1.short.fastq.gz,data/multiplex-reads/CTR101-3_2.short.fastq.gz
+patient101,tumor,ILLUMINA,rg1,data/multiplex-reads/T101-1_1.short.fastq.gz,data/multiplex-reads/T101-1_2.short.fastq.gz
+patient101,tumor,ILLUMINA,rg2,data/multiplex-reads/T101-2_1.short.fastq.gz,data/multiplex-reads/T101-2_2.short.fastq.gz
+patient101,tumor,ILLUMINA,rg3,data/multiplex-reads/T101-3_1.short.fastq.gz,data/multiplex-reads/T101-3_2.short.fastq.gz


### PR DESCRIPTION
This pull request adds panel of normal (PON) functionality to the pipeline. Users can choose to use a PON when calling variants with Mutect2. The PON can be built from scratch using the normal samples that will be analyzed or from a previously generated panel of normals. This update also cleans up the config file. 